### PR TITLE
Fix: Drupal solution: MySQL deployment error due MYSQL_USER

### DIFF
--- a/solutions/drupal/README.md
+++ b/solutions/drupal/README.md
@@ -12,7 +12,7 @@
 ## Deployment Files
 - [Drupal Mysql PV](./drupal-mysql-pv.yaml)
 - [Drupal Mysql PVC](./drupal-mysql-pvc.yaml)
-- Secret - `kubectl create secret generic drupal-mysql-secret --from-literal=MYSQL_ROOT_PASSWORD=root_password --from-literal=MYSQL_DATABASE=drupal-database --from-literal=MYSQL_USER=root`
+- Secret - `kubectl create secret generic drupal-mysql-secret --from-literal=MYSQL_ROOT_PASSWORD=root_password --from-literal=MYSQL_DATABASE=drupal-database`
 - [Drupal Mysql Deployment](./drupal-mysql.yaml)
 - [Drupal Mysql Service](./drupal-mysql-service.yaml)
 - [Drupal PV](./drupal-pv.yaml)

--- a/solutions/drupal/drupal-mysql.yaml
+++ b/solutions/drupal/drupal-mysql.yaml
@@ -32,11 +32,6 @@ spec:
             secretKeyRef:
               name: drupal-mysql-secret
               key: MYSQL_ROOT_PASSWORD
-        - name: MYSQL_USER
-          valueFrom:
-            secretKeyRef:
-              name: drupal-mysql-secret
-              key: MYSQL_USER
         volumeMounts:
         - mountPath: "/var/lib/mysql"
           name: pvc


### PR DESCRIPTION
MySQL deployment pod error while using existing drupal-mysql.yaml config.

There seems no MYSQL_USER anymore at secret.

![image](https://user-images.githubusercontent.com/23030068/166624580-bff83329-f3b6-4147-b71d-c996d1656837.png)


PS. This seems to be a problem with a newer docker version because this used to work before and not throw an error.
Docker PR: https://github.com/docker-library/mysql/pull/749


```
controlplane $ kubectl get pods
NAME                            READY   STATUS    RESTARTS   AGE
drupal-865b5f5594-hz7rz         1/1     Running   0          18m
drupal-mysql-77d6988c7b-x9czh   0/1     Error     4          113s
```

``` kubectl describe pod <podName>
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  41s                default-scheduler  Successfully assigned default/drupal-mysql-77d6988c7b-cx6c6 to node01
  Normal   Pulled     22s (x3 over 40s)  kubelet, node01    Container image "mysql:5.7" already present on machine
  Normal   Created    21s (x3 over 40s)  kubelet, node01    Created container mysql
  Normal   Started    21s (x3 over 40s)  kubelet, node01    Started container mysql
  Warning  BackOff    10s (x4 over 38s)  kubelet, node01    Back-off restarting failed container
```
## Logs
``` logs
controlplane $ kubectl logs -f drupal-mysql-77d6988c7b-cx6c6
2022-05-04 03:43:20+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.38-1debian10 started.
2022-05-04 03:43:20+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2022-05-04 03:43:20+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.38-1debian10 started.
2022-05-04 03:43:20+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
    Remove MYSQL_USER="root" and use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD
```

## Solution

- Removed MYSQL_USER lines in drupal-mysql.yaml

> Refer
[mysql-docker-container-keeps-restarting](https://stackoverflow.com/a/66910240)